### PR TITLE
New tasks: Reformat source code with clang-format-13

### DIFF
--- a/endless-sky/.devcontainer/Dockerfile
+++ b/endless-sky/.devcontainer/Dockerfile
@@ -23,10 +23,25 @@ apt-get install -y curl fuse libfuse2
 # Additional Dev Tools
 RUN set -ex; \
 apt-get update; \
-apt-get install -y git
+apt-get install -y git gnupg2
+
+# Install clang-format v13
+ADD clang-13.list /etc/apt/sources.list.d/
+RUN set -ex; \
+curl -sSfL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
+apt-get update; \
+apt-get install -y clang-format-13
+
+# Sound utilities
+RUN set -ex; \
+apt-get update; \
+apt-get install -y alsa-base pulseaudio libasound2-plugins
 
 # assumes UID 1000
-RUN adduser es-user
+RUN set -ex; \
+adduser es-user; \
+usermod -a -G audio es-user
+
 USER es-user
 WORKDIR /home/es-user
 CMD /bin/bash

--- a/endless-sky/.devcontainer/clang-13.list
+++ b/endless-sky/.devcontainer/clang-13.list
@@ -1,0 +1,3 @@
+# Learn more at http://apt.llvm.org
+deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
+# deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main

--- a/endless-sky/.devcontainer/clang-format
+++ b/endless-sky/.devcontainer/clang-format
@@ -1,0 +1,113 @@
+IndentWidth: 4
+TabWidth: 4
+UseTab: Always
+SpaceBeforeParens: Never
+AccessModifierOffset: -4
+EmptyLineBeforeAccessModifier: Always
+MaxEmptyLinesToKeep: 3
+AllowShortBlocksOnASingleLine: Never
+AlignAfterOpenBracket: DontAlign
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: None
+AlignEscapedNewlines: Left
+AlignOperands: DontAlign
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: false
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: false
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: false
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeConceptDeclarations: true
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: AfterColon
+BreakStringLiterals: false
+ColumnLimit: 120
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DeriveLineEnding: false
+DerivePointerAlignment: false
+DisableFormat: false
+FixNamespaceComments: false
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '^"'
+    Priority:        1
+  - Regex:           '^<(SDL|png|jpeg|uuid)'
+    Priority:        2
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        3
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: Indent
+IndentGotoLabels: false
+IndentPPDirectives: None
+IndentRequires: true
+IndentWrappedFunctionNames: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+Language: Cpp
+NamespaceIndentation: All
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+PointerAlignment: Right
+ShortNamespaceLines: 0
+SortIncludes: true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: Never
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++11
+UseCRLF: false

--- a/endless-sky/.devcontainer/docker-compose.yml
+++ b/endless-sky/.devcontainer/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     command: /bin/bash -c 'while sleep 1000;do true;done'
     #--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined
     devices:
-      - /dev/fuse
       - /dev/dri
+      - /dev/fuse
       - /dev/snd
     cap_add:
       - SYS_ADMIN
@@ -17,8 +17,9 @@ services:
       - 'apparmor:unconfined'
     volumes:
       - ../../../endless-sky:/workspace/endless-sky
-      - .:/workspace/endless-sky/.devcontainer
       - ../.vscode:/workspace/endless-sky/.vscode
+      - .:/workspace/endless-sky/.devcontainer
+      - ./clang-format:/workspace/endless-sky/.clang-format
       - /tmp/.X11-unix:/tmp/.X11-unix
     environment:
       DISPLAY: $DISPLAY

--- a/endless-sky/.vscode/tasks.json
+++ b/endless-sky/.vscode/tasks.json
@@ -2,6 +2,18 @@
     "version": "2.0.0",
     "tasks": [
         {
+            "label": "Format: clang-format-13 my changes",
+            "type": "shell",
+            "command": "PS4='$ '; git-clang-format-13 --binary clang-format-13",
+            "problemMatcher": []
+        },
+        {
+            "label": "Format: clang-format-13 endless-sky master",
+            "type": "shell",
+            "command": "PS4='$ '; set -ex; git fetch https://github.com/endless-sky/endless-sky.git master; git-clang-format-13 --binary clang-format-13 --commit $(git merge-base FETCH_HEAD HEAD)",
+            "problemMatcher": []
+        },
+        {
             "label": "Build: Compile Endless Sky OpenGL Desktop",
             "type": "shell",
             "command": "PS4='$ '; set -ex; scons -Qj $(nproc) opengl=desktop",
@@ -52,11 +64,11 @@
             }
         },
         {
-            "label": "Workspace: Reset AppImage Continuous",
+            "label": "Package: Reset AppImage Continuous",
             "type": "shell",
             "command": "PS4='$ '; set -e; for x in XCode/EndlessSky-Info.plist credits.txt endless-sky.6 source/main.cpp; do ( set -x; git checkout \"$x\"; ); done; set -x; rm -f *.AppImage",
             "problemMatcher": []
-        }
+        },
         {
             "label": "Package: AppImage Continuous",
             "type": "shell",

--- a/endless-sky/README.md
+++ b/endless-sky/README.md
@@ -19,14 +19,17 @@ VSCode Tasks
 All tasks are based on endless-sky GitHub actions.  See also [how to run tasks
 in VSCode][howto-tasks].
 
-| Task name                                 | Purpose                                            |
-| ----------------------------------------- | -------------------------------------------------- |
-| Build: Compile Endless Sky OpenGL Desktop | Build game                                         |
-| Build: Clean and Reset Workspace          | Removes build files<sup>1</sup>                    |
-| Test: Run tests                           | Execute unit tests and report result               |
-| Test: Run benchmarks                      | Runs benchmarks on the test executable<sup>2</sup> |
-| Test: Run headless integration tests      | Execute integration tests within Xvfb<sup>3</sup>  |
-| Package: AppImage Continuous              | Create an AppImage for running anywhere            |
+| Task name                                  | Purpose                                              |
+| ------------------------------------------ | ---------------------------------------------------- |
+| Format: clang-format-13 my changes         | Reformat my changes to match clang v13 code style.   |
+| Format: clang-format-13 endless-sky master | Reformat my changes since endless-sky master branch. |
+| Build: Compile Endless Sky OpenGL Desktop  | Build game                                           |
+| Build: Clean and Reset Workspace           | Removes build files<sup>1</sup>                      |
+| Test: Run tests                            | Execute unit tests and report result                 |
+| Test: Run benchmarks                       | Runs benchmarks on the test executable<sup>2</sup>   |
+| Test: Run headless integration tests       | Execute integration tests within Xvfb<sup>3</sup>    |
+| Package: Reset AppImage Continuous         | Reset git workspace for rebuilding AppImage.         |
+| Package: AppImage Continuous               | Create an AppImage for play testing on Linux.        |
 
 > **Notes:**
 > 1. Not fully complete.  Run `git clean -xfdn` for a dryrun clean.  You can run


### PR DESCRIPTION
* `.clang-format` provided by @quyykk on [ES discord][discord].
* Suggestion to use `git-clang-format` provided by @quyykk.
* @samrocketman added two new tasks which are useful for endless sky development.
  1. Reformat all source code which hasn't been committed, yet.
  2. Reformat all source code since the current branch diverged from upstream [endless-sky master branch][es].  This is useful for long-running branches to ensure all code is properly formatted.

# Screenshot

![Screenshot taken at 2022-04-03_14-44-25](https://user-images.githubusercontent.com/875669/161443240-f2eaf420-182f-41cc-bf62-14bd890babf6.png)

[discord]: https://discord.com/channels/251118043411775489/285540320823869441/960183348205092924
[es]: https://github.com/endless-sky/endless-sky