### PR TITLE
Use CMake instead of scons

### DIFF
--- a/endless-sky/.devcontainer/CMakeUserPresets.json
+++ b/endless-sky/.devcontainer/CMakeUserPresets.json
@@ -1,0 +1,47 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "docker",
+      "displayName": "Devcontainer",
+      "inherits": "linux",
+      "cacheVariables": {
+        "ES_USE_SYSTEM_LIBRARIES": "OFF"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "docker-debug",
+      "displayName": "Debug",
+      "configurePreset": "docker",
+      "inherits": "debug"
+    },
+    {
+      "name": "docker-release",
+      "displayName": "Release",
+      "configurePreset": "docker",
+      "inherits": "release"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "docker-test",
+      "displayName": "Tests",
+      "configurePreset": "docker",
+      "inherits": "test"
+    },
+    {
+      "name": "docker-benchmark",
+      "displayName": "Benchmarks",
+      "configurePreset": "docker",
+      "inherits": "benchmark"
+    },
+    {
+      "name": "docker-integration",
+      "displayName": "Integration Tests",
+      "configurePreset": "docker",
+      "inherits": "integration"
+    }
+  ]
+}

--- a/endless-sky/.devcontainer/Dockerfile
+++ b/endless-sky/.devcontainer/Dockerfile
@@ -4,13 +4,22 @@ VOLUME /tmp
 VOLUME /var/cache/apt/archives
 
 ENV DEBIAN_FRONTEND=noninteractive
-
-SHELL [ "/bin/sh", "-exc" ]
+SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 # Endless sky requirements
 RUN \
   apt-get update; \
-  apt-get install -y g++ scons libsdl2-dev libpng-dev libjpeg-dev libgl1-mesa-dev libglew-dev libopenal-dev libmad0-dev uuid-dev
+  apt-get install -y make zip unzip curl tar gzip pkg-config bison autoconf libtool; \
+  apt-get install -y g++ libgl1-mesa-dev libglu1-mesa-dev libx11-dev libxft-dev libxext-dev
+
+# Install latest cmake and ninja
+RUN \
+  cd /usr/local; \
+  curl -sSfL https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz | tar --strip-components=1 -xz; \
+  cd bin/; \
+  curl -sSfLO https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip; \
+  unzip ninja-linux.zip; \
+  rm ninja-linux.zip
 
 # Integration test dependencies
 RUN \
@@ -20,7 +29,7 @@ RUN \
 # AppImage requirements
 RUN \
   apt-get update; \
-  apt-get install -y curl fuse libfuse2 rsync
+  apt-get install -y curl rsync
 
 # Additional Dev Tools
 RUN \
@@ -44,7 +53,7 @@ RUN \
   apt-get update; \
   apt-get install -y alsa-base pulseaudio libasound2-plugins
 
-# Mac OS and packaging dependencies
+# Packaging dependencies
 RUN \
   apt-get update; \
   apt-get install -y python3.9 python3.9-venv
@@ -56,15 +65,6 @@ RUN \
 
 USER es-user
 WORKDIR /home/es-user
-
-# set up Mac OS XCode support
-RUN \
-  python3.9 -m venv ~/venv; \
-  . ~/venv/bin/activate; \
-  pip install wheel==0.37.1; \
-  pip install docopt==0.6.2 openstep-parser==1.5.3 pbxproj==3.4.0; \
-  pip install regex; \
-  echo 'source ~/venv/bin/activate' >> ~/.bashrc
 
 # set up global gitignore
 RUN \

--- a/endless-sky/.devcontainer/Dockerfile
+++ b/endless-sky/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN \
 # AppImage requirements
 RUN \
   apt-get update; \
-  apt-get install -y curl rsync
+  apt-get install -y rsync
 
 # Additional Dev Tools
 RUN \

--- a/endless-sky/.devcontainer/devcontainer.json
+++ b/endless-sky/.devcontainer/devcontainer.json
@@ -9,7 +9,10 @@
         "mhutchie.git-graph",
         "ms-vscode.cpptools-extension-pack",
         "shardulm94.trailing-spaces",
-        "thomasballinger.endless-sky-vscode"
+        "thomasballinger.endless-sky-vscode",
+		"fredericbonnet.cmake-test-adapter",
+		"EditorConfig.EditorConfig",
+		"redhat.vscode-yaml"
     ],
     "settings": {
         "endlesssky.executablePath": "/workspace/endless-sky/endless-sky",

--- a/endless-sky/.devcontainer/devcontainer.json
+++ b/endless-sky/.devcontainer/devcontainer.json
@@ -10,9 +10,9 @@
         "ms-vscode.cpptools-extension-pack",
         "shardulm94.trailing-spaces",
         "thomasballinger.endless-sky-vscode",
-		"fredericbonnet.cmake-test-adapter",
-		"EditorConfig.EditorConfig",
-		"redhat.vscode-yaml"
+        "fredericbonnet.cmake-test-adapter",
+        "EditorConfig.EditorConfig",
+        "redhat.vscode-yaml"
     ],
     "settings": {
         "endlesssky.executablePath": "/workspace/endless-sky/endless-sky",

--- a/endless-sky/.devcontainer/docker-compose.yml
+++ b/endless-sky/.devcontainer/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - ../.vscode:/workspace/endless-sky/.vscode
       - .:/workspace/endless-sky/.devcontainer
       - ./clang-format:/workspace/endless-sky/.clang-format
+      - ./CMakeUserPresets.json:/workspace/endless-sky/CMakeUserPresets.json
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /run/user/${UID:-1000}/pulse/native:/run/user/${UID:-1000}/pulse/native
     environment:

--- a/endless-sky/.devcontainer/requirements.txt
+++ b/endless-sky/.devcontainer/requirements.txt
@@ -1,5 +1,0 @@
-certifi==2021.10.8
-dulwich==0.20.33
-PyYAML==5.4.1
-semver==2.13.0
-urllib3==1.26.8

--- a/endless-sky/.vscode/c_cpp_properties.json
+++ b/endless-sky/.vscode/c_cpp_properties.json
@@ -3,14 +3,14 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**",
-                "/usr/include/SDL2"
+                "${workspaceFolder}/**"
             ],
             "defines": [],
             "compilerPath": "/usr/bin/gcc",
-            "cStandard": "gnu17",
-            "cppStandard": "gnu++14",
-            "intelliSenseMode": "linux-gcc-x64"
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "linux-gcc-x64",
+            "configurationProvider": "ms-vscode.cmake-tools"
         }
     ],
     "version": 4

--- a/endless-sky/.vscode/launch.json
+++ b/endless-sky/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "cppdbg",
             "request": "launch",
             "preLaunchTask": "Build: Compile Endless Sky OpenGL Desktop",
-            "program": "${workspaceFolder}/endless-sky",
+            "program": "${command:cmake.launchTargetPath}",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",

--- a/endless-sky/.vscode/tasks.json
+++ b/endless-sky/.vscode/tasks.json
@@ -3,10 +3,7 @@
     "tasks": [
         {
             "label": "ES Data: Run Conversation",
-            "command": "${command:endlesssky.talk}",
-            "dependsOn": [
-                "Build: Compile Endless Sky OpenGL Desktop"
-            ]
+            "command": "${command:endlesssky.talk}"
         },
         {
             "label": "ES Data: Insert Snippet",
@@ -59,64 +56,12 @@
             "problemMatcher": []
         },
         {
-            "label": "Code: Update XCode with upstream master",
-            "type": "shell",
-            "command": "PS4='$ '; source ~/venv/bin/activate; set -ex; git fetch https://github.com/endless-sky/endless-sky.git master; git checkout FETCH_HEAD EndlessSky.xcodeproj/project.pbxproj; ./utils/check_xcode.sh && git checkout HEAD EndlessSky.xcodeproj/project.pbxproj || rm xcode-project.patch",
-            "problemMatcher": []
-        },
-        {
             "label": "Build: Clean and Reset Workspace",
             "type": "shell",
             "command": "PS4='$ '; set -x; scons -c; scons -c tests; rm -f *.AppImage endless-sky.png; git checkout credits.txt XCode/EndlessSky-Info.plist endless-sky.6 source/main.cpp",
             "problemMatcher": [],
             "group": {
                 "kind": "build",
-                "isDefault": false
-            }
-        },
-        {
-            "label": "Build: Compile Endless Sky OpenGL Desktop",
-            "type": "shell",
-            "command": "PS4='$ '; set -ex; scons -Qj $(nproc) opengl=desktop mode=debug",
-            "problemMatcher": [],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
-        },
-        {
-            "label": "Test: Run tests",
-            "type": "shell",
-            "command": "PS4='$ '; set -ex; scons -Qj $(nproc) test",
-            "problemMatcher": [],
-            "group": {
-                "kind": "test",
-                "isDefault": false
-            }
-        },
-        {
-            "label": "Test: Run benchmarks",
-            "type": "shell",
-            "command": "PS4='$ '; if [ ! -x ./tests/endless-sky-tests ]; then tput setaf 1; echo 'Execute `Build: Run tests` first...' >&2; tput sgr 0; exit 1; fi; set -ex; ./tests/endless-sky-tests '[!benchmark]'",
-            "problemMatcher": [],
-            "dependsOn": [
-                "Test: Run tests"
-            ],
-            "group": {
-                "kind": "test",
-                "isDefault": false
-            }
-        },
-        {
-            "label": "Test: Run headless integration tests",
-            "type": "shell",
-            "command": "PS4='$ '; set -ex; export PRINT_GLXINFO=true;  ./tests/integration/run_tests_headless.sh",
-            "problemMatcher": [],
-            "dependsOn": [
-                "Build: Compile Endless Sky OpenGL Desktop"
-            ],
-            "group": {
-                "kind": "test",
                 "isDefault": false
             }
         },


### PR DESCRIPTION
- Use CMake to build instead of scons
- The quick tasks that build and test are no longer necessary, they are replaced by the bottom bar actions
- I've added a couple of useful extensions too
- Removed the XCode quick task because it is no longer needed

When starting the container the first time you will get a message prompting you to select a configure preset, select "Devcontainer".