### PR TITLE
Some small fixes

### DIFF
--- a/endless-sky/.devcontainer/devcontainer.json
+++ b/endless-sky/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
         "redhat.vscode-yaml"
     ],
     "settings": {
-        "endlesssky.executablePath": "/workspace/endless-sky/endless-sky",
+        "endlesssky.executablePath": "${command:cmake.launchTargetPath}",
         "files.associations": {
             "**/data/**/*.txt": "endlesssky"
         },

--- a/endless-sky/.vscode/launch.json
+++ b/endless-sky/.vscode/launch.json
@@ -5,7 +5,6 @@
             "name": "Debug: Launch ES",
             "type": "cppdbg",
             "request": "launch",
-            "preLaunchTask": "Build: Compile Endless Sky OpenGL Desktop",
             "program": "${command:cmake.launchTargetPath}",
             "args": [],
             "stopAtEntry": false,

--- a/endless-sky/.vscode/settings.json
+++ b/endless-sky/.vscode/settings.json
@@ -71,5 +71,8 @@
         "locale": "cpp",
         "queue": "cpp",
         "stack": "cpp"
-    }
+    },
+    "git.ignoredRepositories": [
+        "/workspace/endless-sky/vcpkg"
+    ]
 }


### PR DESCRIPTION
This is a collection of 3 fixes:

- Fixes the path to the ES executable for the talk task
- Remove the invalid preLaunchTask from launch.json
- Adds vcpkg to the ignored git repository setting, so that it doesn't appear under source control